### PR TITLE
Bugfix: crossenv used to inject env variables  

### DIFF
--- a/neutralino.config.json
+++ b/neutralino.config.json
@@ -29,7 +29,7 @@
         "devUrl": "http://localhost:3000",
         "projectPath": "/react-src/",
         "initCommand": "npm install",
-        "devCommand": "BROWSER=none npm start",
+        "devCommand": "npm run start",
         "buildCommand": "npm run build"
     }
   }

--- a/react-src/package.json
+++ b/react-src/package.json
@@ -13,7 +13,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "cross-env BROWSER=none react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
@@ -35,5 +35,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.3"
   }
 }


### PR DESCRIPTION
This PR fixes Timeout exceeded issue by using cross-env to inject `BROWSER=none` env variable while running the neu run command.

Old way `BROWSER=none npm start` does not work anymore.

Dont wanted to add cross-env to neutralinojs-cli package since all frameworks require different methods to disable browser window, and this is only react specific, therefore made changes in react-src/package.json instead of neutralino.config.json

fixes: #7 